### PR TITLE
fix: warning from latex2exp::TeX()

### DIFF
--- a/28_Advanced_Graphing.Rmd
+++ b/28_Advanced_Graphing.Rmd
@@ -389,15 +389,11 @@ ggplot(data, aes(x=x)) +
   geom_point(aes(y=y)) +
   geom_line(aes(y=fit), color='blue') +
   annotate('text', x=9, y=9.5, 
-           label=latex2exp::TeX('$\\hat{\\rho}$ = 0.916') ) +   # always double \\
-  labs( x=latex2exp::TeX('X-axis $\\alpha$'), 
-        y=latex2exp::TeX('Y: $\\log_{10}$(Income)'),
-        title=latex2exp::TeX('Linear Models use: $\\hat{\\beta} = (X^TX)^{-1}X^Ty$'))
+           label=latex2exp::TeX('$\\hat{\\rho}$ = 0.916'), output="character" ) +   # always double \\
+  labs( x=latex2exp::TeX('X-axis $\\alpha$', output="character"), 
+        y=latex2exp::TeX('Y: $\\log_{10}$(Income)', output="character"),
+        title=latex2exp::TeX('Linear Models use: $\\hat{\\beta} = (X^TX)^{-1}X^Ty$', output="character"))
 ```
-
-The warning message that is produced is coming from `ggplot` and I haven't
-figured out how to avoid it. Because it is giving us the graph we want, I'm just
-going to ignore the error for now.
 
 One issue is how to add expression to a data frame. Unfortunately, neither
 `data.frame` nor `tibble` will allow a column of expressions, so instead we have


### PR DESCRIPTION
@dereksonderegger I think this should eliminate your warning message. I had the same problem and found the solution here
https://github.com/stefano-meschiari/latex2exp/issues/29#issuecomment-771288608

Also see the latex2exp documentation for `TeX()` where the description for the argument `output` states
> The returned object, one of "expression" (default, returns a plotmath expression ready for plotting), "character" (returns the expression as a string), and "ast" (returns the tree used to generate the expression).

Perhaps there's a simpler solution than having to explicitly state `output = "character"` on every call to `latex2exp::TeX()`, but I'm still pretty new to R, so if there  is I don't see it. If anyone has a better suggestion I'd be happy to hear it.